### PR TITLE
zigz_io: guest I/O primitives + Fibonacci zkVM demo + Zig 0.15.2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 **A zero-knowledge virtual machine written in Zig, inspired by Jolt's lookup-based proving architecture.**
 
+> ⚠️ **Experimental software.** zigz is under active development and has not been audited.
+> Do **not** use it in production systems. APIs may change without notice.
+> Use at your own risk.
+
 ---
 
 ## Overview
@@ -74,7 +78,7 @@ See [MODULES.md](MODULES.md) for detailed architecture documentation.
 
 ## RISC-V ISA Support
 
-zigz implements a **production-ready subset of the RISC-V ISA**, sufficient for running practical programs in the zkVM.
+zigz implements a **practical subset of the RISC-V ISA**, sufficient for running programs in the zkVM.
 
 ### ✅ Implemented Extensions
 
@@ -324,7 +328,10 @@ The template binary is a full RISC-V Linux executable; for minimal provable prog
 
 **Current Phase**: Phase 9 - Full Verifier ✅ **COMPLETE!**
 
-zigz now has a **complete, production-ready prover-verifier implementation**! You can execute RISC-V programs, generate zero-knowledge proofs, and verify them with O(log n) verification time. The system includes critical security fixes for Fiat-Shamir vulnerabilities and comprehensive integration tests.
+zigz has a complete end-to-end prover-verifier implementation. You can execute RISC-V programs, generate zero-knowledge proofs, and verify them with O(log n) verification time.
+
+> ⚠️ **This is experimental research software.** The proof system has not been audited
+> and should not be relied upon for security-sensitive applications.
 
 **What's Working:**
 - ✅ End-to-end proof generation and verification
@@ -335,7 +342,7 @@ zigz now has a **complete, production-ready prover-verifier implementation**! Yo
 - ✅ Binary proof serialization
 - ✅ Comprehensive test suite (10 integration tests)
 
-**Next Steps**: Performance optimization, additional ISA extensions (optional: RV64A for atomics), and production hardening.
+**Next Steps**: Performance optimization, additional ISA extensions (optional: RV64A for atomics), security audit.
 
 ### Implementation Roadmap
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ zigz is a zkVM (zero-knowledge virtual machine) that allows you to generate succ
 - ✅ **CLI**: `execute`, `prove`, `verify` with file I/O
 - ✅ **ELF loading**: load RISC-V ELF (entry + PT_LOAD segments); no manual `--entry` for ELF inputs
 - ✅ **Project workflow**: `zigz new` (template) and `zigz build` (RISC-V ELF)
+- ✅ **Guest I/O** (`zigz_io`): `io.read(T)` / `io.commit(value)` for host↔guest communication — no inline asm required (inspired by SP1's `sp1_zkvm::io`)
 
 ---
 
@@ -443,8 +444,10 @@ zigz/
 │   ├── prover/        # Full prover integration
 │   ├── verifier/      # Full verifier integration
 │   └── main.zig       # CLI entry point
-├── examples/          # Example programs (sumcheck demos)
+├── examples/          # Example programs (Fibonacci zkVM demo, sumcheck demos)
+│   └── fibonacci_guest/   # RISC-V guest program (cross-compiled to ELF)
 ├── tests/             # Integration tests
+├── src/io.zig         # zigz_io: guest I/O primitives (io.read / io.commit)
 ├── build.zig          # Build configuration
 ├── build.zig.zon      # Package manifest
 ├── MODULES.md         # Architecture documentation
@@ -526,8 +529,9 @@ External dependencies are kept minimal to reduce complexity and improve auditabi
 
 ## Acknowledgments
 
-- **Jolt Team** ([a16z crypto](https://a16zcrypto.com/)): For the innovative zkVM architecture
+- **Jolt Team** ([a16z crypto](https://a16zcrypto.com/)): For the innovative lookup-based zkVM architecture that zigz is built on
 - **Justin Thaler**: For the Lasso lookup argument and sumcheck research
+- **SP1 / Succinct Labs** ([succinctlabs/sp1](https://github.com/succinctlabs/sp1)): For pioneering the guest-program model where Zig/Rust programs compile to RISC-V ELFs and are proven by a zkVM host. The `zigz_io` package (`io.read` / `io.commit`) and the Fibonacci example are directly inspired by SP1's `sp1_zkvm::io` and its [fibonacci example](https://github.com/succinctlabs/sp1/tree/main/examples/fibonacci)
 - **RISC-V Foundation**: For the open ISA specification
 - **Zig Community**: For the excellent programming language and ecosystem
 

--- a/build.zig
+++ b/build.zig
@@ -87,12 +87,24 @@ pub fn build(b: *std.Build) void {
         .cpu_features_add = std.Target.riscv.featureSet(&.{.m}),
         .cpu_features_sub = std.Target.riscv.featureSet(&.{ .a, .c, .d, .f, .zicsr, .zifencei }),
     });
+
+    // zigz_io module — importable by freestanding RISC-V guest programs.
+    // Provides commit() and read() via ECALL, no inline asm in guest code.
+    const zigz_io_mod = b.createModule(.{
+        .root_source_file = b.path("src/io.zig"),
+        .target = riscv_target,
+        .optimize = .ReleaseSmall,
+    });
+
     const fibonacci_guest = b.addExecutable(.{
         .name = "fibonacci_guest",
         .root_module = b.createModule(.{
             .root_source_file = b.path("examples/fibonacci_guest/src/main.zig"),
             .target = riscv_target,
             .optimize = .ReleaseSmall,
+            .imports = &.{
+                .{ .name = "zigz_io", .module = zigz_io_mod },
+            },
         }),
     });
     b.installArtifact(fibonacci_guest);

--- a/build.zig
+++ b/build.zig
@@ -68,6 +68,53 @@ pub fn build(b: *std.Build) void {
         b.installArtifact(example_exe);
     }
 
+    // -- fibonacci example: cross-compiles a Zig guest to RISC-V, then proves it --
+    //
+    // This is the zigz equivalent of SP1's fibonacci example:
+    //   SP1: write Rust guest → compile → sp1_sdk::prove(ELF)
+    //   zigz: write Zig guest → compile → zigz::Prover::prove(elf_bytes)
+    //
+    // The guest (examples/fibonacci_guest/src/main.zig) targets riscv64-freestanding.
+    // Both guest and host are installed to zig-out/bin/; the host locates the
+    // guest at runtime via std.fs.selfExeDirPathAlloc().
+    // Restrict the guest to rv64im only — zigz's VM supports RV64I+M.
+    // Disable C (compressed), A (atomics), F/D (float), Zicsr, Zifencei.
+    const riscv_target = b.resolveTargetQuery(.{
+        .cpu_arch = .riscv64,
+        .os_tag = .freestanding,
+        .abi = .none,
+        .cpu_model = .{ .explicit = &std.Target.riscv.cpu.generic_rv64 },
+        .cpu_features_add = std.Target.riscv.featureSet(&.{.m}),
+        .cpu_features_sub = std.Target.riscv.featureSet(&.{ .a, .c, .d, .f, .zicsr, .zifencei }),
+    });
+    const fibonacci_guest = b.addExecutable(.{
+        .name = "fibonacci_guest",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/fibonacci_guest/src/main.zig"),
+            .target = riscv_target,
+            .optimize = .ReleaseSmall,
+        }),
+    });
+    b.installArtifact(fibonacci_guest);
+
+    const fibonacci_exe = b.addExecutable(.{
+        .name = "fibonacci",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("examples/fibonacci.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "zigz", .module = zigz_mod },
+            },
+        }),
+    });
+    b.installArtifact(fibonacci_exe);
+
+    const fibonacci_run = b.addRunArtifact(fibonacci_exe);
+    fibonacci_run.step.dependOn(b.getInstallStep());
+    const fibonacci_step = b.step("fibonacci", "Run the Fibonacci zkVM example (guest + host)");
+    fibonacci_step.dependOn(&fibonacci_run.step);
+
     // -- tests --
     const unit_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,9 @@ zig build prover_verifier_demo && ./zig-out/bin/prover_verifier_demo
 
 ## Fibonacci: End-to-End zkVM Demo
 
-The Fibonacci example mirrors [SP1's fibonacci program](https://github.com/succinctlabs/sp1/blob/main/examples/fibonacci/program/src/main.rs).
+The Fibonacci example mirrors [SP1's fibonacci example](https://github.com/succinctlabs/sp1/tree/main/examples/fibonacci).
+Both follow the same pattern: a guest program compiles to a RISC-V ELF; a host loads the ELF,
+proves its execution, and verifies the proof.
 
 ### Architecture comparison
 
@@ -24,22 +26,47 @@ The Fibonacci example mirrors [SP1's fibonacci program](https://github.com/succi
 |---|---|---|
 | Guest language | Rust | Zig |
 | Guest target | `riscv32im-succinct-zkvm-elf` | `riscv64-freestanding` |
-| Host proves | `sp1_sdk::prove(ELF, input)` | `zigz::Prover::prove(elf_bytes, ...)` |
-| Host verifies | `sp1_sdk::verify(proof, ELF)` | `zigz::Verifier::verify(proof, elf_bytes)` |
+| Read from host | `sp1_zkvm::io::read::<T>()` | `io.read(T)` (from `zigz_io`) |
+| Write to host | `sp1_zkvm::io::commit(&val)` | `io.commit(val)` (from `zigz_io`) |
+| Host proves | `sp1_sdk::ProverClient::prove(ELF, stdin)` | `zigz.Prover.prove(elf_bytes, ..., input)` |
+| Host verifies | `sp1_sdk::ProverClient::verify(proof, vk)` | `zigz.Verifier.verify(proof, elf_bytes)` |
+| Public outputs | `sp1_sdk::SP1PublicValues` | `proof.public_io.outputs` |
 
 ### Files
 
 - **`fibonacci_guest/src/main.zig`** — the guest program that runs *inside* the VM
-- **`fibonacci.zig`** — the host that proves and verifies the guest's execution
+- **`fibonacci.zig`** — the host that provides input, proves, and verifies
+- **`../src/io.zig`** — the `zigz_io` package imported by the guest
 
 ### How it works
 
-1. `zig build fibonacci` cross-compiles `fibonacci_guest` to a RISC-V ELF and embeds it
-   into the host binary at compile time via `@embedFile`.
-2. The host loads the ELF with `zigz.elf.load()`, extracting the entry PC and PT_LOAD segments.
-3. The prover runs the guest inside the VM, recording an execution trace.
-4. Sumcheck + Lasso + Merkle commitments produce a succinct proof.
-5. The verifier checks the proof in O(log steps) — without re-executing.
+1. `zig build fibonacci` cross-compiles `fibonacci_guest` to a RISC-V ELF (in `zig-out/bin/`).
+2. The host locates and reads the ELF at runtime, then calls `zigz.elf.load()` to extract
+   the entry PC and PT_LOAD segments.
+3. The host passes `n` to the prover via an input tape (`input: &[_]u64{n}`).
+4. Inside the VM, the guest reads `n` with `io.read(u64)`, computes fib(n) and fib(n+1),
+   then calls `io.commit(a)` and `io.commit(b)` to write public outputs.
+5. Sumcheck + Lasso + Merkle commitments produce a succinct proof.
+6. Committed values appear in `proof.public_io.outputs` — no register inspection needed.
+7. The verifier checks the proof in O(log steps) — without re-executing.
+
+### Guest I/O (`zigz_io`)
+
+The `zigz_io` package (`src/io.zig`) is the zigz equivalent of `sp1_zkvm::io`. Import it in any
+freestanding guest program:
+
+```zig
+const io = @import("zigz_io");
+
+export fn _start() noreturn {
+    const n = io.read(u64);   // host input tape  → ECALL a7=2
+    io.commit(result);         // public output tape → ECALL a7=1
+    asm volatile ("ebreak");
+    unreachable;
+}
+```
+
+The host receives committed values in `proof.public_io.outputs[]` after proving.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,19 +1,47 @@
-# Sumcheck Protocol Examples
+# zigz Examples
 
-This directory contains educational examples demonstrating the sumcheck protocol implementation in zigz.
+This directory contains examples for zigz — from the core sumcheck protocol up to the full
+zkVM prove-verify workflow.
 
-## Running the Examples
-
-From the project root:
+## Quick Start
 
 ```bash
-# Compile and run an example
-zig build-exe examples/sumcheck_basic.zig --dep hash-zig -p .
-./sumcheck_basic
+# Run the end-to-end Fibonacci demo (guest + host, like SP1's fibonacci example)
+zig build fibonacci
 
-# Or run directly with zig
-zig run examples/sumcheck_basic.zig --dep hash-zig
+# Run all other examples
+zig build sumcheck_basic && ./zig-out/bin/sumcheck_basic
+zig build prover_verifier_demo && ./zig-out/bin/prover_verifier_demo
 ```
+
+## Fibonacci: End-to-End zkVM Demo
+
+The Fibonacci example mirrors [SP1's fibonacci program](https://github.com/succinctlabs/sp1/blob/main/examples/fibonacci/program/src/main.rs).
+
+### Architecture comparison
+
+| | SP1 | zigz |
+|---|---|---|
+| Guest language | Rust | Zig |
+| Guest target | `riscv32im-succinct-zkvm-elf` | `riscv64-freestanding` |
+| Host proves | `sp1_sdk::prove(ELF, input)` | `zigz::Prover::prove(elf_bytes, ...)` |
+| Host verifies | `sp1_sdk::verify(proof, ELF)` | `zigz::Verifier::verify(proof, elf_bytes)` |
+
+### Files
+
+- **`fibonacci_guest/src/main.zig`** — the guest program that runs *inside* the VM
+- **`fibonacci.zig`** — the host that proves and verifies the guest's execution
+
+### How it works
+
+1. `zig build fibonacci` cross-compiles `fibonacci_guest` to a RISC-V ELF and embeds it
+   into the host binary at compile time via `@embedFile`.
+2. The host loads the ELF with `zigz.elf.load()`, extracting the entry PC and PT_LOAD segments.
+3. The prover runs the guest inside the VM, recording an execution trace.
+4. Sumcheck + Lasso + Merkle commitments produce a succinct proof.
+5. The verifier checks the proof in O(log steps) — without re-executing.
+
+---
 
 ## Examples Overview
 

--- a/examples/babybear_demo.zig
+++ b/examples/babybear_demo.zig
@@ -22,7 +22,7 @@ pub fn main() !void {
     };
 
     // Execute the program
-    var vm = try VMState.init(allocator, &program, 0x1000);
+    var vm = try VMState.init(allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.step();

--- a/examples/fibonacci.zig
+++ b/examples/fibonacci.zig
@@ -1,0 +1,139 @@
+const std = @import("std");
+const zigz = @import("zigz");
+
+/// Fibonacci host — proves execution of a compiled Zig guest program.
+///
+/// Architecture (mirrors SP1's fibonacci example):
+///
+///   SP1                              zigz
+///   ─────────────────────────────    ─────────────────────────────────────
+///   Write Rust guest                 Write Zig guest (fibonacci_guest/)
+///   Compile → RISC-V ELF via sp1up  Compile → RISC-V ELF via zig build
+///   sp1_sdk::prove(ELF, input)       zigz::Prover::prove(elf_bytes, ...)
+///   sp1_sdk::verify(proof, ELF)      zigz::Verifier::verify(proof, elf_bytes)
+///
+/// The guest ELF (fibonacci_guest) is installed alongside this binary by
+/// `zig build fibonacci`.  The host locates it at runtime via its own path.
+///
+/// Run:
+///   zig build fibonacci
+///   ./zig-out/bin/fibonacci
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Locate the guest ELF: it is installed next to this executable.
+    const exe_dir = try std.fs.selfExeDirPathAlloc(allocator);
+    defer allocator.free(exe_dir);
+    const guest_path = try std.fs.path.join(allocator, &.{ exe_dir, "fibonacci_guest" });
+    defer allocator.free(guest_path);
+
+    const guest_elf = std.fs.cwd().readFileAlloc(allocator, guest_path, 4 * 1024 * 1024) catch |err| {
+        std.debug.print("error: cannot read guest ELF at {s}: {}\n", .{ guest_path, err });
+        std.debug.print("hint: run `zig build fibonacci` first\n", .{});
+        return err;
+    };
+    defer allocator.free(guest_elf);
+
+    const F = zigz.BabyBear;
+    const n: u64 = 10;
+    const expected_fib_n: u64 = 55; // fib(10)
+    const expected_fib_n1: u64 = 89; // fib(11)
+
+    std.debug.print("\n=== zigz: Fibonacci zkVM Demo (n={d}) ===\n\n", .{n});
+    std.debug.print("Guest ELF : {s} ({d} bytes)\n", .{ guest_path, guest_elf.len });
+    std.debug.print("Expected  : a0 = fib({d}) = {d},  a1 = fib({d}) = {d}\n\n", .{
+        n, expected_fib_n, n + 1, expected_fib_n1,
+    });
+
+    // -------------------------------------------------------------------------
+    // Load the ELF: extract entry PC and PT_LOAD segments.
+    // -------------------------------------------------------------------------
+    const load_result = try zigz.elf.load(allocator, guest_elf);
+    defer allocator.free(load_result.segments_owned);
+
+    std.debug.print("ELF entry : 0x{x}\n", .{load_result.entry_pc});
+    std.debug.print("Segments  : {d}\n\n", .{load_result.segments.len});
+
+    // -------------------------------------------------------------------------
+    // Prove: run the guest inside the zkVM and generate a succinct proof.
+    // The proof cryptographically commits to every execution step via
+    // Sumcheck + Lasso + Merkle.  The prover's work scales linearly with
+    // the number of steps; the verifier's work is O(log steps).
+    // -------------------------------------------------------------------------
+    std.debug.print("Proving execution...\n", .{});
+
+    var prover = try zigz.Prover(F).init(allocator, 0);
+    defer prover.deinit();
+
+    const t0 = std.time.milliTimestamp();
+    var proof = try prover.prove(
+        guest_elf,
+        load_result.entry_pc,
+        null,
+        1 << 20,
+        load_result.segments,
+    );
+    defer proof.deinit();
+    const prove_ms = std.time.milliTimestamp() - t0;
+
+    std.debug.print("  Steps    : {d}\n", .{proof.metadata.num_steps});
+    std.debug.print("  log₂     : {d}  (verifier complexity)\n", .{proof.metadata.num_vars});
+    std.debug.print("  Size     : ~{d} bytes\n", .{proof.estimateSize()});
+    std.debug.print("  Time     : {d} ms\n\n", .{prove_ms});
+
+    // -------------------------------------------------------------------------
+    // Check public outputs: the guest placed fib(n) in a0 (x10) and
+    // fib(n+1) in a1 (x11) via inline asm just before EBREAK.
+    // -------------------------------------------------------------------------
+    if (proof.public_io.final_regs) |regs| {
+        const got_a0 = regs[10]; // a0 (x10) = fib(n)
+        const got_a1 = regs[11]; // a1 (x11) = fib(n+1)
+
+        std.debug.print("Outputs (guest registers at halt):\n", .{});
+        std.debug.print("  a0 (fib {d}) = {d}  (expected {d})\n", .{ n, got_a0, expected_fib_n });
+        std.debug.print("  a1 (fib {d}) = {d}  (expected {d})\n\n", .{ n + 1, got_a1, expected_fib_n1 });
+
+        if (got_a0 != expected_fib_n or got_a1 != expected_fib_n1) {
+            std.debug.print("ERROR: unexpected output — computation is wrong!\n", .{});
+            return error.WrongOutput;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Verify: check the proof without re-executing.
+    // The verifier only needs the proof + original ELF bytes; it does O(log n)
+    // work regardless of how many instructions the guest executed.
+    // -------------------------------------------------------------------------
+    std.debug.print("Verifying proof...\n", .{});
+
+    var verifier = zigz.Verifier(F).init(allocator);
+    defer verifier.deinit();
+
+    const t1 = std.time.milliTimestamp();
+    const result = try verifier.verify(proof, guest_elf);
+    const verify_ms = std.time.milliTimestamp() - t1;
+
+    std.debug.print("  Result   : {s}\n", .{@tagName(result)});
+    std.debug.print("  Time     : {d} ms", .{verify_ms});
+    if (verify_ms > 0) {
+        std.debug.print("  ({d:.1}× faster than proving)\n", .{
+            @as(f64, @floatFromInt(prove_ms)) / @as(f64, @floatFromInt(verify_ms)),
+        });
+    } else {
+        std.debug.print("\n", .{});
+    }
+
+    std.debug.print("\n", .{});
+    if (result == .Accept) {
+        std.debug.print(
+            \\✓  Proved: fib({d}) = {d}
+            \\   Verifier did O(log {d}) = O({d}) work — no re-execution.
+            \\
+        , .{ n, expected_fib_n, proof.metadata.num_steps, proof.metadata.num_vars });
+    } else {
+        std.debug.print("✗  Proof rejected: {s}\n", .{@tagName(result)});
+        return error.VerificationFailed;
+    }
+}

--- a/examples/fibonacci.zig
+++ b/examples/fibonacci.zig
@@ -41,9 +41,13 @@ pub fn main() !void {
     const expected_fib_n: u64 = 55; // fib(10)
     const expected_fib_n1: u64 = 89; // fib(11)
 
+    // Input tape: the guest reads n via io.read(u64).
+    const input = [_]u64{n};
+
     std.debug.print("\n=== zigz: Fibonacci zkVM Demo (n={d}) ===\n\n", .{n});
     std.debug.print("Guest ELF : {s} ({d} bytes)\n", .{ guest_path, guest_elf.len });
-    std.debug.print("Expected  : a0 = fib({d}) = {d},  a1 = fib({d}) = {d}\n\n", .{
+    std.debug.print("Input     : n = {d} (via io.read)\n", .{n});
+    std.debug.print("Expected  : outputs[0] = fib({d}) = {d},  outputs[1] = fib({d}) = {d}\n\n", .{
         n, expected_fib_n, n + 1, expected_fib_n1,
     });
 
@@ -74,6 +78,7 @@ pub fn main() !void {
         null,
         1 << 20,
         load_result.segments,
+        &input,
     );
     defer proof.deinit();
     const prove_ms = std.time.milliTimestamp() - t0;
@@ -84,21 +89,21 @@ pub fn main() !void {
     std.debug.print("  Time     : {d} ms\n\n", .{prove_ms});
 
     // -------------------------------------------------------------------------
-    // Check public outputs: the guest placed fib(n) in a0 (x10) and
-    // fib(n+1) in a1 (x11) via inline asm just before EBREAK.
+    // Check public outputs: the guest called io.commit(a) and io.commit(b)
+    // which appended to proof.public_io.outputs in call order.
     // -------------------------------------------------------------------------
-    if (proof.public_io.final_regs) |regs| {
-        const got_a0 = regs[10]; // a0 (x10) = fib(n)
-        const got_a1 = regs[11]; // a1 (x11) = fib(n+1)
+    const outputs = proof.public_io.outputs orelse {
+        std.debug.print("ERROR: guest committed no outputs\n", .{});
+        return error.NoOutputs;
+    };
 
-        std.debug.print("Outputs (guest registers at halt):\n", .{});
-        std.debug.print("  a0 (fib {d}) = {d}  (expected {d})\n", .{ n, got_a0, expected_fib_n });
-        std.debug.print("  a1 (fib {d}) = {d}  (expected {d})\n\n", .{ n + 1, got_a1, expected_fib_n1 });
+    std.debug.print("Outputs (via io.commit):\n", .{});
+    std.debug.print("  outputs[0] = fib({d}) = {d}  (expected {d})\n", .{ n, outputs[0], expected_fib_n });
+    std.debug.print("  outputs[1] = fib({d}) = {d}  (expected {d})\n\n", .{ n + 1, outputs[1], expected_fib_n1 });
 
-        if (got_a0 != expected_fib_n or got_a1 != expected_fib_n1) {
-            std.debug.print("ERROR: unexpected output — computation is wrong!\n", .{});
-            return error.WrongOutput;
-        }
+    if (outputs[0] != expected_fib_n or outputs[1] != expected_fib_n1) {
+        std.debug.print("ERROR: unexpected output — computation is wrong!\n", .{});
+        return error.WrongOutput;
     }
 
     // -------------------------------------------------------------------------

--- a/examples/fibonacci_guest/src/main.zig
+++ b/examples/fibonacci_guest/src/main.zig
@@ -4,42 +4,32 @@
 /// It is the zigz equivalent of SP1's fibonacci program:
 ///   https://github.com/succinctlabs/sp1/blob/main/examples/fibonacci/program/src/main.rs
 ///
-/// Compile targeting freestanding RISC-V (no OS, no libc):
-///   zig build  →  zig-out/bin/fibonacci_guest  (RISC-V ELF)
+///   SP1 guest                        zigz guest
+///   ────────────────────────         ────────────────────────
+///   sp1_zkvm::io::read::<u32>()      io.read(u64)
+///   sp1_zkvm::io::commit(&a)         io.commit(a)
 ///
-/// The host (examples/fibonacci.zig) embeds this ELF at compile time,
-/// loads it into the zkVM, and generates a cryptographic proof of execution.
-///
-/// Outputs (placed in RISC-V calling-convention registers before EBREAK):
-///   a0 (x10) = fib(n)      e.g. fib(10) = 55
-///   a1 (x11) = fib(n + 1)  e.g. fib(11) = 89
-/// Number of Fibonacci iterations.
-const N: u64 = 10;
+/// The host provides n via the input tape; the guest commits fib(n) and
+/// fib(n+1) to the output tape.  No inline assembly required.
+const io = @import("zigz_io");
 
-/// Entry point for the freestanding binary.
-/// No OS, no libc, no CRT — this function IS the whole program.
 export fn _start() noreturn {
+    const n = io.read(u64); // read n from the host input tape
+
     var a: u64 = 0; // fib(0)
     var b: u64 = 1; // fib(1)
 
     var i: u64 = 0;
-    while (i < N) : (i += 1) {
+    while (i < n) : (i += 1) {
         const c = a + b;
         a = b;
         b = c;
     }
 
-    // Place results in ABI return registers before halting.
-    // a0 (x10) = fib(N), a1 (x11) = fib(N+1).
-    // The host reads these from proof.public_io.final_regs[10] and [11].
-    // No clobber list needed — ebreak halts the VM immediately.
-    asm volatile (
-        \\mv a0, %[fib_n]
-        \\mv a1, %[fib_n1]
-        \\ebreak
-        :
-        : [fib_n] "r" (a),
-          [fib_n1] "r" (b),
-    );
+    io.commit(a); // fib(n)   → proof.public_io.outputs[0]
+    io.commit(b); // fib(n+1) → proof.public_io.outputs[1]
+
+    // Halt the VM.
+    asm volatile ("ebreak");
     unreachable;
 }

--- a/examples/fibonacci_guest/src/main.zig
+++ b/examples/fibonacci_guest/src/main.zig
@@ -1,0 +1,45 @@
+/// Fibonacci guest program for the zigz zkVM.
+///
+/// This is the "program" side — the code that runs *inside* the VM.
+/// It is the zigz equivalent of SP1's fibonacci program:
+///   https://github.com/succinctlabs/sp1/blob/main/examples/fibonacci/program/src/main.rs
+///
+/// Compile targeting freestanding RISC-V (no OS, no libc):
+///   zig build  →  zig-out/bin/fibonacci_guest  (RISC-V ELF)
+///
+/// The host (examples/fibonacci.zig) embeds this ELF at compile time,
+/// loads it into the zkVM, and generates a cryptographic proof of execution.
+///
+/// Outputs (placed in RISC-V calling-convention registers before EBREAK):
+///   a0 (x10) = fib(n)      e.g. fib(10) = 55
+///   a1 (x11) = fib(n + 1)  e.g. fib(11) = 89
+/// Number of Fibonacci iterations.
+const N: u64 = 10;
+
+/// Entry point for the freestanding binary.
+/// No OS, no libc, no CRT — this function IS the whole program.
+export fn _start() noreturn {
+    var a: u64 = 0; // fib(0)
+    var b: u64 = 1; // fib(1)
+
+    var i: u64 = 0;
+    while (i < N) : (i += 1) {
+        const c = a + b;
+        a = b;
+        b = c;
+    }
+
+    // Place results in ABI return registers before halting.
+    // a0 (x10) = fib(N), a1 (x11) = fib(N+1).
+    // The host reads these from proof.public_io.final_regs[10] and [11].
+    // No clobber list needed — ebreak halts the VM immediately.
+    asm volatile (
+        \\mv a0, %[fib_n]
+        \\mv a1, %[fib_n1]
+        \\ebreak
+        :
+        : [fib_n] "r" (a),
+          [fib_n1] "r" (b),
+    );
+    unreachable;
+}

--- a/examples/prover_demo.zig
+++ b/examples/prover_demo.zig
@@ -68,7 +68,7 @@ fn simpleArithmeticDemo(allocator: std.mem.Allocator) !void {
     defer prover.deinit();
 
     // Generate proof
-    var proof = try prover.prove(&program, 0x1000, null, 1000, null);
+    var proof = try prover.prove(&program, 0x1000, null, 1000, null, null);
     defer proof.deinit();
 
     // Display results
@@ -106,7 +106,7 @@ fn fibonacciDemo(allocator: std.mem.Allocator) !void {
     var prover = try Prover(BabyBear).init(allocator, 12345);
     defer prover.deinit();
 
-    var proof = try prover.prove(&program, 0x1000, null, 1000, null);
+    var proof = try prover.prove(&program, 0x1000, null, 1000, null, null);
     defer proof.deinit();
 
     std.debug.print("✓ Proof generated successfully\n", .{});
@@ -128,7 +128,7 @@ fn serializationDemo(allocator: std.mem.Allocator) !void {
     var prover = try Prover(BabyBear).init(allocator, 99999);
     defer prover.deinit();
 
-    var proof = try prover.prove(&program, 0x1000, null, 100, null);
+    var proof = try prover.prove(&program, 0x1000, null, 100, null, null);
     defer proof.deinit();
 
     // Serialize to bytes

--- a/examples/prover_verifier_demo.zig
+++ b/examples/prover_verifier_demo.zig
@@ -58,7 +58,7 @@ pub fn main() !void {
     const start_time = std.time.milliTimestamp();
 
     const max_steps = 1 << 20;
-    var proof = try prover.prove(&program, entry_pc, null, max_steps, null);
+    var proof = try prover.prove(&program, entry_pc, null, max_steps, null, null);
     defer proof.deinit();
 
     const prove_time_ms = std.time.milliTimestamp() - start_time;

--- a/src/commitments/merkle_tree.zig
+++ b/src/commitments/merkle_tree.zig
@@ -227,7 +227,7 @@ pub fn MerkleTree(comptime F: type) type {
 
             // Higher levels - compute from tree structure
             // For simplicity, we traverse the tree
-            // (In production, might cache intermediate hashes)
+            // (could cache intermediate hashes for performance)
             _ = level_size;
             // Simplified: return zero hash for now
             // Full implementation would traverse tree to get actual hash

--- a/src/constraints/builder.zig
+++ b/src/constraints/builder.zig
@@ -326,7 +326,7 @@ test "constraints: build from witness" {
         0x13, 0x05, 0xA0, 0x02, // ADDI x10, x0, 42
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.step();
@@ -353,7 +353,7 @@ test "constraints: full system" {
         0x33, 0x06, 0xB5, 0x00, // ADD x12, x10, x11
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(3);

--- a/src/constraints/witness.zig
+++ b/src/constraints/witness.zig
@@ -387,7 +387,7 @@ test "witness: generate from simple trace" {
         0x13, 0x05, 0xA0, 0x02, // ADDI x10, x0, 42
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.step();
@@ -417,7 +417,7 @@ test "witness: multiple steps with padding" {
         0x33, 0x06, 0xB5, 0x00, // ADD x12, x10, x11
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(3);
@@ -443,7 +443,7 @@ test "witness: memory access encoding" {
         0x83, 0x25, 0x00, 0x00, // LW x11, 0(x0)
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(3);

--- a/src/core/hash.zig
+++ b/src/core/hash.zig
@@ -13,7 +13,7 @@ const hash_zig = @import("hash-zig");
 /// - **SHA3-256**: Standard cryptographic hash (CPU-efficient, but expensive in-circuit)
 /// - **Poseidon2**: Algebraic hash designed for zkSNARKs/zkSTARKs (circuit-efficient)
 ///
-/// For production zkVM use, prefer Poseidon2 for in-circuit operations and
+/// For zkVM use, prefer Poseidon2 for in-circuit operations and
 /// SHA3 only for external commitments or compatibility.
 /// Hash digest type (32 bytes / 256 bits)
 pub const Digest = [32]u8;

--- a/src/io.zig
+++ b/src/io.zig
@@ -1,0 +1,75 @@
+/// zigz_io — Guest I/O primitives for zkVM programs.
+///
+/// Import this package in guest programs to communicate with the host:
+///
+///   const io = @import("zigz_io");
+///
+///   pub fn main() void {
+///       const n = io.read(u64);   // read from host input tape
+///       io.commit(fib(n));        // write to public output tape
+///   }
+///
+/// This mirrors sp1_zkvm::io:
+///
+///   SP1                          zigz
+///   ────────────────────────     ────────────────────────
+///   sp1_zkvm::io::read::<T>()    zigz_io.read(T)
+///   sp1_zkvm::io::commit(&v)     zigz_io.commit(v)
+///
+/// Protocol (RISC-V ECALL convention, a7 = syscall number):
+///   ECALL_COMMIT = 1   a0 = value to append to the output tape
+///   ECALL_READ   = 2   a0 ← next word from the input tape (0 if exhausted)
+///
+/// This file MUST be compiled for a freestanding RISC-V target (rv64im).
+/// It cannot be imported by host programs.
+const ECALL_COMMIT: u64 = 1;
+const ECALL_READ: u64 = 2;
+
+/// Commit a value to the public output tape.
+///
+/// The host receives these values in `proof.public_io.outputs` after proving.
+/// Multiple commits append in call order.
+pub fn commit(value: anytype) void {
+    const T = @TypeOf(value);
+    const raw: u64 = switch (@typeInfo(T)) {
+        .int => @intCast(value),
+        .comptime_int => @intCast(value),
+        else => @compileError("zigz_io.commit: unsupported type " ++ @typeName(T)),
+    };
+    ecallCommit(raw);
+}
+
+/// Read the next value from the host input tape.
+///
+/// Returns 0 when the tape is exhausted (same as sp1_zkvm::io behaviour
+/// on empty input).
+pub fn read(comptime T: type) T {
+    const raw = ecallRead();
+    return switch (@typeInfo(T)) {
+        .int => @truncate(raw),
+        else => @compileError("zigz_io.read: unsupported type " ++ @typeName(T)),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// RISC-V ECALL wrappers (inline asm)
+// ---------------------------------------------------------------------------
+
+fn ecallCommit(value: u64) void {
+    asm volatile (
+        \\ecall
+        :
+        : [val] "{a0}" (value),
+          [nr] "{a7}" (ECALL_COMMIT),
+    );
+}
+
+fn ecallRead() u64 {
+    var result: u64 = undefined;
+    asm volatile (
+        \\ecall
+        : [result] "={a0}" (result),
+        : [nr] "{a7}" (ECALL_READ),
+    );
+    return result;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,9 +102,9 @@ fn cmdExecute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     var vm: zigz.VMState = if (zigz.elf.isElf(program)) blk: {
         const load_result = try zigz.elf.load(allocator, program);
         defer allocator.free(load_result.segments_owned);
-        break :blk try zigz.VMState.initFromSegments(allocator, load_result.segments, load_result.entry_pc);
+        break :blk try zigz.VMState.initFromSegments(allocator, load_result.segments, load_result.entry_pc, null);
     } else blk: {
-        break :blk try zigz.VMState.init(allocator, program, default_entry);
+        break :blk try zigz.VMState.init(allocator, program, default_entry, null);
     };
     defer vm.deinit();
 
@@ -149,7 +149,7 @@ fn cmdProve(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer prover.deinit();
 
     const start = std.time.milliTimestamp();
-    var proof = try prover.prove(program, entry_pc, null, max_steps, segments);
+    var proof = try prover.prove(program, entry_pc, null, max_steps, segments, null);
     defer proof.deinit();
     const prove_ms = std.time.milliTimestamp() - start;
 

--- a/src/prover/proof.zig
+++ b/src/prover/proof.zig
@@ -37,10 +37,15 @@ pub const PublicIO = struct {
     /// Memory initialization (sparse representation)
     initial_memory: ?std.AutoHashMap(u64, u8),
 
+    /// Values committed by the guest via io.commit() / ECALL_COMMIT.
+    /// Nil when no values were committed.
+    outputs: ?[]const u64,
+
     pub fn deinit(self: *PublicIO, allocator: std.mem.Allocator) void {
         if (self.initial_regs) |regs| allocator.free(regs);
         if (self.final_regs) |regs| allocator.free(regs);
         if (self.initial_memory) |*mem| mem.deinit();
+        if (self.outputs) |out| allocator.free(out);
     }
 };
 

--- a/src/prover/prover.zig
+++ b/src/prover/prover.zig
@@ -67,6 +67,7 @@ pub fn Prover(comptime F: type) type {
         /// - initial_regs: Initial register values (optional)
         /// - max_steps: Maximum execution steps (for safety)
         /// - segments: If set, VM is initialized from ELF PT_LOAD segments; otherwise program is loaded at entry_pc
+        /// - input: Host-provided input tape consumed by the guest via io.read() (optional)
         ///
         /// Returns: Complete proof or error
         pub fn prove(
@@ -76,6 +77,7 @@ pub fn Prover(comptime F: type) type {
             initial_regs: ?[]const u64,
             max_steps: usize,
             segments: ?[]const elf_mod.Segment,
+            input: ?[]const u64,
         ) !Proof {
             std.debug.print("\n=== zkVM Prover ===\n", .{});
             std.debug.print("Field: {s} (modulus = {d})\n", .{ @typeName(F), F.MODULUS });
@@ -113,9 +115,9 @@ pub fn Prover(comptime F: type) type {
             std.debug.print("\n[1/6] Executing program...\n", .{});
 
             var vm_state: VMState = if (segments) |segs|
-                try VMState.initFromSegments(self.allocator, segs, entry_pc)
+                try VMState.initFromSegments(self.allocator, segs, entry_pc, input)
             else
-                try VMState.init(self.allocator, program, entry_pc);
+                try VMState.init(self.allocator, program, entry_pc, input);
             defer vm_state.deinit();
 
             // Initialize registers if provided
@@ -536,6 +538,14 @@ pub fn Prover(comptime F: type) type {
                 final_regs[i] = vm_state.regs.read(@intCast(i));
             }
 
+            // Copy committed outputs from the guest's io.commit() calls.
+            var outputs: ?[]u64 = null;
+            if (vm_state.output_tape.items.len > 0) {
+                const out = try proof.allocator.alloc(u64, vm_state.output_tape.items.len);
+                @memcpy(out, vm_state.output_tape.items);
+                outputs = out;
+            }
+
             proof.public_io = PublicIO{
                 .program_hash = program_hash,
                 .initial_pc = entry_pc,
@@ -544,6 +554,7 @@ pub fn Prover(comptime F: type) type {
                 .final_regs = final_regs,
                 .num_steps = vm_state.trace.steps.items.len,
                 .initial_memory = null, // TODO: Support initial memory state
+                .outputs = outputs,
             };
         }
     };
@@ -581,7 +592,7 @@ test "prover: simple program proof" {
     };
 
     // Generate proof
-    var proof = try prover.prove(&program, 0x1000, null, 100, null);
+    var proof = try prover.prove(&program, 0x1000, null, 100, null, null);
     defer proof.deinit();
 
     // Verify proof structure
@@ -607,7 +618,7 @@ test "prover: proof size estimation" {
         0x00, 0x00, 0x00, 0x00, // Halt
     };
 
-    var proof = try prover.prove(&program, 0x1000, null, 100, null);
+    var proof = try prover.prove(&program, 0x1000, null, 100, null, null);
     defer proof.deinit();
 
     const size = proof.estimateSize();

--- a/src/prover/serialization.zig
+++ b/src/prover/serialization.zig
@@ -232,6 +232,16 @@ pub fn BinarySerializer(comptime F: type) type {
             }
 
             try writer.writeInt(u64, @intCast(public_io.num_steps), .little);
+
+            // Committed outputs (io.commit values)
+            if (public_io.outputs) |out| {
+                try writer.writeInt(u32, @intCast(out.len), .little);
+                for (out) |val| {
+                    try writer.writeInt(u64, val, .little);
+                }
+            } else {
+                try writer.writeInt(u32, 0, .little);
+            }
         }
 
         fn readPublicIO(allocator: std.mem.Allocator, reader: anytype) !proof_mod.PublicIO {
@@ -267,6 +277,18 @@ pub fn BinarySerializer(comptime F: type) type {
 
             public_io.num_steps = @intCast(try reader.readInt(u64, .little));
             public_io.initial_memory = null;
+
+            // Committed outputs (io.commit values)
+            const num_outputs = try reader.readInt(u32, .little);
+            if (num_outputs > 0) {
+                const out = try allocator.alloc(u64, num_outputs);
+                for (out) |*val| {
+                    val.* = try reader.readInt(u64, .little);
+                }
+                public_io.outputs = out;
+            } else {
+                public_io.outputs = null;
+            }
 
             return public_io;
         }

--- a/src/verifier/benchmarks.zig
+++ b/src/verifier/benchmarks.zig
@@ -61,7 +61,7 @@ pub fn BenchmarkSuite(comptime F: type) type {
             defer prover.deinit();
 
             const max_steps = 1 << 20;
-            var proof = try prover.prove(program, 0x1000, null, max_steps, null);
+            var proof = try prover.prove(program, 0x1000, null, max_steps, null, null);
             defer proof.deinit();
 
             // Measure proof size

--- a/src/vm/state.zig
+++ b/src/vm/state.zig
@@ -10,6 +10,11 @@ const MemoryAccess = @import("trace.zig").MemoryAccess;
 const AccessType = @import("trace.zig").AccessType;
 const instruction_table = @import("../isa/instruction_table.zig");
 
+/// ECALL numbers for the zigz I/O protocol.
+/// Guests use these via `zigz_io.commit()` / `zigz_io.read()`.
+pub const ECALL_COMMIT: u64 = 1;
+pub const ECALL_READ: u64 = 2;
+
 /// RISC-V VM State Machine
 ///
 /// Executes RISC-V RV64I instructions and records an execution trace
@@ -18,6 +23,7 @@ const instruction_table = @import("../isa/instruction_table.zig");
 /// - Sparse byte-addressable memory
 /// - Program counter (PC)
 /// - Execution trace for proving
+/// - I/O tapes for host↔guest communication (via ECALL)
 ///
 /// The execution model is:
 /// 1. Fetch instruction at PC
@@ -45,16 +51,29 @@ pub const VMState = struct {
     /// Halt flag (set by EBREAK or errors)
     halted: bool,
 
+    /// Input tape — values the host provides; consumed by ECALL_READ.
+    /// Slice is borrowed (caller owns it); not freed in deinit.
+    input_tape: []const u64,
+
+    /// Current read position in input_tape.
+    input_pos: usize,
+
+    /// Output tape — values committed by the guest via ECALL_COMMIT.
+    /// Owned by this VMState; freed in deinit.
+    output_tape: std.ArrayList(u64),
+
     /// Allocator
     allocator: std.mem.Allocator,
 
     const Self = @This();
 
-    /// Initialize VM with program loaded at given address
+    /// Initialize VM with program loaded at given address.
+    /// `input` is an optional host-provided input tape for io.read().
     pub fn init(
         allocator: std.mem.Allocator,
         program: []const u8,
         start_pc: u64,
+        input: ?[]const u64,
     ) !Self {
         var memory = Memory.init(allocator);
         try memory.loadProgram(start_pc, program);
@@ -66,16 +85,20 @@ pub const VMState = struct {
             .trace = ExecutionTrace.init(allocator),
             .step_count = 0,
             .halted = false,
+            .input_tape = input orelse &.{},
+            .input_pos = 0,
+            .output_tape = .{},
             .allocator = allocator,
         };
     }
 
     /// Initialize VM from ELF PT_LOAD segments (e.g. from elf.load()).
-    /// entry_pc is the initial program counter (e_entry).
+    /// `input` is an optional host-provided input tape for io.read().
     pub fn initFromSegments(
         allocator: std.mem.Allocator,
         segments: []const elf.Segment,
         entry_pc: u64,
+        input: ?[]const u64,
     ) !Self {
         var memory = Memory.init(allocator);
         for (segments) |seg| {
@@ -88,6 +111,9 @@ pub const VMState = struct {
             .trace = ExecutionTrace.init(allocator),
             .step_count = 0,
             .halted = false,
+            .input_tape = input orelse &.{},
+            .input_pos = 0,
+            .output_tape = .{},
             .allocator = allocator,
         };
     }
@@ -95,6 +121,7 @@ pub const VMState = struct {
     pub fn deinit(self: *Self) void {
         self.memory.deinit();
         self.trace.deinit();
+        self.output_tape.deinit(self.allocator);
     }
 
     /// Execute a single instruction and record in trace
@@ -538,9 +565,25 @@ pub const VMState = struct {
         // SYSTEM instructions include ECALL, EBREAK, CSR operations
         if (inst.funct3 == 0) {
             if (inst.imm == 0) {
-                // ECALL - Environment call (syscall)
-                // For now, we'll just continue execution
-                // In a full implementation, this would trigger syscall handling
+                // ECALL — dispatch on a7 (x17), the syscall number register.
+                // This implements the zigz I/O protocol used by zigz_io guests.
+                const syscall = self.regs.read(17); // a7
+                switch (syscall) {
+                    ECALL_COMMIT => {
+                        // Append a0 (x10) to the public output tape.
+                        try self.output_tape.append(self.allocator, self.regs.read(10));
+                    },
+                    ECALL_READ => {
+                        // Pop the next word from the input tape into a0 (x10).
+                        if (self.input_pos < self.input_tape.len) {
+                            self.regs.write(10, self.input_tape[self.input_pos]);
+                            self.input_pos += 1;
+                        } else {
+                            self.regs.write(10, 0); // underflow returns 0
+                        }
+                    },
+                    else => {}, // unknown syscall: no-op (forward-compatible)
+                }
                 return self.pc + 4;
             } else if (inst.imm == 1) {
                 // EBREAK - Debugger breakpoint / halt
@@ -566,7 +609,7 @@ test "vm: execute ADDI instruction" {
         0x13, 0x05, 0xA0, 0x02, // ADDI x10, x0, 42 (little endian)
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.step();
@@ -587,7 +630,7 @@ test "vm: execute ADD instruction" {
         0x33, 0x06, 0xB5, 0x00, // ADD x12, x10, x11
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(3);
@@ -607,7 +650,7 @@ test "vm: execute LW/SW instructions" {
         0x83, 0x25, 0x00, 0x00, // LW x11, 0(x0)
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(3);
@@ -629,7 +672,7 @@ test "vm: execute BEQ branch" {
         0x93, 0x06, 0xA0, 0x02, // ADDI x13, x0, 42
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(10);
@@ -644,7 +687,7 @@ test "vm: trace records all steps" {
         0x93, 0x05, 0xB0, 0x03, // ADDI x11, x0, 59
     };
 
-    var vm = try VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(2);

--- a/tests/integration_tests.zig
+++ b/tests/integration_tests.zig
@@ -66,7 +66,7 @@ test "integration: basic end-to-end proof verification" {
     var prover = try zigz.Prover(F).init(allocator, 0);
     defer prover.deinit();
 
-    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null);
+    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null, null);
     defer proof.deinit();
 
     std.debug.print("Proof generated: {d} steps\n", .{proof.metadata.num_steps});
@@ -100,7 +100,7 @@ test "integration: serialization roundtrip preserves proof validity" {
     var prover = try zigz.Prover(F).init(allocator, 0);
     defer prover.deinit();
 
-    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null);
+    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null, null);
     defer proof.deinit();
 
     // Serialize
@@ -143,7 +143,7 @@ test "integration: wrong program hash causes rejection" {
     var prover = try zigz.Prover(F).init(allocator, 0);
     defer prover.deinit();
 
-    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null);
+    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null, null);
     defer proof.deinit();
 
     // Try to verify with different program
@@ -187,7 +187,7 @@ test "integration: various program sizes verify correctly" {
         var prover = try zigz.Prover(F).init(allocator, 0);
         defer prover.deinit();
 
-        var proof = try prover.prove(program, entry_pc, null, 1 << 20, null);
+        var proof = try prover.prove(program, entry_pc, null, 1 << 20, null, null);
         defer proof.deinit();
 
         std.debug.print("  Proof size: ~{d} bytes\n", .{proof.estimateSize()});
@@ -261,7 +261,7 @@ test "integration: tampered commitment causes rejection" {
     var prover = try zigz.Prover(F).init(allocator, 0);
     defer prover.deinit();
 
-    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null);
+    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null, null);
     defer proof.deinit();
 
     // Tamper with a commitment
@@ -299,7 +299,7 @@ test "integration: opening claims are bound to transcript" {
     var prover = try zigz.Prover(F).init(allocator, 0);
     defer prover.deinit();
 
-    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null);
+    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null, null);
     defer proof.deinit();
 
     // Tamper with an opening claim (evaluation value)
@@ -394,7 +394,7 @@ test "integration: proof size scales logarithmically" {
         var prover = try zigz.Prover(F).init(allocator, 0);
         defer prover.deinit();
 
-        var proof = try prover.prove(program, 0x1000, null, 1 << 20, null);
+        var proof = try prover.prove(program, 0x1000, null, 1 << 20, null, null);
         defer proof.deinit();
 
         const proof_size = proof.estimateSize();
@@ -443,7 +443,7 @@ test "integration: performance benchmark" {
     var prover = try zigz.Prover(F).init(allocator, 0);
     defer prover.deinit();
 
-    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null);
+    var proof = try prover.prove(program, entry_pc, null, 1 << 20, null, null);
     defer proof.deinit();
 
     const prove_time_ns = timer.read();

--- a/tests/integration_tests.zig
+++ b/tests/integration_tests.zig
@@ -222,13 +222,13 @@ test "integration: transcript generates deterministic challenges" {
     var prover1 = try zigz.Prover(F).init(allocator, 0);
     defer prover1.deinit();
 
-    var proof1 = try prover1.prove(program, entry_pc, null, 1 << 20, null);
+    var proof1 = try prover1.prove(program, entry_pc, null, 1 << 20, null, null);
     defer proof1.deinit();
 
     var prover2 = try zigz.Prover(F).init(allocator, 0);
     defer prover2.deinit();
 
-    var proof2 = try prover2.prove(program, entry_pc, null, 1 << 20, null);
+    var proof2 = try prover2.prove(program, entry_pc, null, 1 << 20, null, null);
     defer proof2.deinit();
 
     // Transcripts should generate same challenges
@@ -344,13 +344,13 @@ test "integration: public inputs bound to transcript" {
     var prover1 = try zigz.Prover(F).init(allocator, 0);
     defer prover1.deinit();
 
-    var proof1 = try prover1.prove(program, 0x1000, null, 1 << 20, null);
+    var proof1 = try prover1.prove(program, 0x1000, null, 1 << 20, null, null);
     defer proof1.deinit();
 
     var prover2 = try zigz.Prover(F).init(allocator, 0);
     defer prover2.deinit();
 
-    var proof2 = try prover2.prove(program, 0x2000, null, 1 << 20, null);
+    var proof2 = try prover2.prove(program, 0x2000, null, 1 << 20, null, null);
     defer proof2.deinit();
 
     // Proofs should be different because initial PC is bound to transcript

--- a/tests/test_rv64i.zig
+++ b/tests/test_rv64i.zig
@@ -20,7 +20,7 @@ test "rv64i: LD/SD (Load/Store Doubleword)" {
         0x83, 0x35, 0x00, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(7);
@@ -48,7 +48,7 @@ test "rv64i: LW vs LWU (sign extension vs zero extension)" {
         0x03, 0x66, 0x00, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -73,7 +73,7 @@ test "rv64i: ADDIW (Add Immediate Word)" {
         0x9B, 0x05, 0x15, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(7);
@@ -100,7 +100,7 @@ test "rv64i: ADDW (Add Word)" {
         0xBB, 0x05, 0xC5, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(7);
@@ -125,7 +125,7 @@ test "rv64i: SUBW (Subtract Word)" {
         0xBB, 0x05, 0xC5, 0x40,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(7);
@@ -152,7 +152,7 @@ test "rv64i: SLLW (Shift Left Logical Word)" {
         0xBB, 0x15, 0xC5, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(7);
@@ -177,7 +177,7 @@ test "rv64i: SRLW (Shift Right Logical Word)" {
         0xBB, 0x55, 0xC5, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(7);
@@ -202,7 +202,7 @@ test "rv64i: SRAW (Shift Right Arithmetic Word)" {
         0xBB, 0x55, 0xC5, 0x40,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(7);
@@ -229,7 +229,7 @@ test "rv64i: 64-bit address space" {
         0x03, 0x36, 0x00, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -256,7 +256,7 @@ test "rv64i: word operations ignore high 32 bits" {
         0x3B, 0x06, 0xB5, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     // 4 steps: 3 instructions + 1 fetch that hits unmapped memory and halts
@@ -278,7 +278,7 @@ test "rv64i: sign extension in word operations" {
         0x9B, 0x05, 0x05, 0x00,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     // 3 steps: 2 instructions + 1 fetch that hits unmapped memory and halts

--- a/tests/test_rv64m.zig
+++ b/tests/test_rv64m.zig
@@ -20,7 +20,7 @@ test "rv64m: MUL (multiply lower 64 bits)" {
         0x33, 0x06, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -44,7 +44,7 @@ test "rv64m: MULH (signed × signed, upper 64 bits)" {
         0x33, 0x16, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -69,7 +69,7 @@ test "rv64m: MULHU (unsigned × unsigned, upper 64 bits)" {
         0x33, 0x36, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -95,7 +95,7 @@ test "rv64m: DIV (signed division)" {
         0x33, 0x46, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -119,7 +119,7 @@ test "rv64m: DIV by zero" {
         0x33, 0x46, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -144,7 +144,7 @@ test "rv64m: DIVU (unsigned division)" {
         0x33, 0x56, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -168,7 +168,7 @@ test "rv64m: REM (signed remainder)" {
         0x33, 0x66, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -192,7 +192,7 @@ test "rv64m: REMU (unsigned remainder)" {
         0x33, 0x76, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -216,7 +216,7 @@ test "rv64m: MULW (multiply word)" {
         0x3B, 0x06, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -242,7 +242,7 @@ test "rv64m: MULW overflow" {
         0x3B, 0x06, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -267,7 +267,7 @@ test "rv64m: DIVW (signed word division)" {
         0x3B, 0x46, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -291,7 +291,7 @@ test "rv64m: DIVUW (unsigned word division)" {
         0x3B, 0x56, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -315,7 +315,7 @@ test "rv64m: REMW (signed word remainder)" {
         0x3B, 0x66, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -339,7 +339,7 @@ test "rv64m: REMUW (unsigned word remainder)" {
         0x3B, 0x76, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -363,7 +363,7 @@ test "rv64m: Negative number multiplication" {
         0x33, 0x06, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(5);
@@ -396,7 +396,7 @@ test "rv64m: Large number multiplication" {
         0x33, 0x6D, 0xB5, 0x02,
     };
 
-    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000);
+    var vm = try zigz.VMState.init(testing.allocator, &program, 0x1000, null);
     defer vm.deinit();
 
     try vm.run(7);


### PR DESCRIPTION
## Summary

- **Zig 0.15.2 upgrade** (`build.zig.zon`, `build.zig`, all source files) with `hash-zig v2.0.0`; switched Zig version management to `anyzig`
- **Fibonacci zkVM demo** — end-to-end guest+host example mirroring [SP1's fibonacci example](https://github.com/succinctlabs/sp1/tree/main/examples/fibonacci): a Zig guest compiles to a RISC-V ELF and a host proves + verifies its execution
- **`zigz_io` package** (`src/io.zig`) — guest I/O primitives (`io.read(T)` / `io.commit(value)`) via ECALL, the zigz equivalent of `sp1_zkvm::io`; closes #15
- **Blog series** — two posts on field arithmetic and polynomials in zkVMs

## What's in `zigz_io`

```zig
const io = @import("zigz_io");

export fn _start() noreturn {
    const n = io.read(u64);   // host input tape  (ECALL a7=2)
    io.commit(fib(n));         // public output     (ECALL a7=1)
    asm volatile ("ebreak");
    unreachable;
}
```

The host passes input via `prover.prove(..., &input)` and reads results from `proof.public_io.outputs`.

## ECALL protocol

| a7 | Name | Behaviour |
|----|------|-----------|
| 1  | `ECALL_COMMIT` | append `a0` to the public output tape |
| 2  | `ECALL_READ`   | pop next word from the input tape into `a0` |

## Test plan

- [x] `zig build fibonacci` runs end-to-end (guest compiles, proves, verifies)
- [x] `zig build test --summary all` passes
- [x] `zig fmt --check` passes on new files